### PR TITLE
Fix model sort reset

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -597,7 +597,7 @@ class Model
     public function resetOrderBy()
     {
         $this->queries = $this->queries->reject(function ($query) {
-            return $query['method'] == 'orderBy' || $query['method'] == 'orderByDesc';
+            return in_array($query['method'], ['orderBy', 'orderByDesc', 'orderByRaw']);
         });
     }
 


### PR DESCRIPTION
## Summary
- ensure `resetOrderBy()` removes `orderByRaw` clauses

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840605be4dc8323b0600c0b5bb42f55