### PR TITLE
Update role selection check

### DIFF
--- a/src/Console/CreateUserCommand.php
+++ b/src/Console/CreateUserCommand.php
@@ -40,7 +40,7 @@ class CreateUserCommand extends Command
         /** @var array $selected */
         $selectedOption = $roles->pluck('name')->toArray();
 
-        if (empty($selectedOption)) {
+        if (! empty($selectedOption)) {
             $selected = $this->choice('Please choose a role for the user', $selectedOption, null, null, true);
 
             $roles = $roles->filter(function ($role) use ($selected) {


### PR DESCRIPTION
## Summary
- ensure create-user role selection only prompts when roles exist

## Testing
- `composer test` *(fails: PHPUnit requires DOM/XML extensions and test setup issues)*

------
https://chatgpt.com/codex/tasks/task_e_6840653d1c5c8323a7a284f8dd6ec06a