### PR TITLE
docs: fix typo in Box comment

### DIFF
--- a/src/Widgets/Box.php
+++ b/src/Widgets/Box.php
@@ -165,7 +165,7 @@ class Box extends Widget implements Renderable
     }
 
     /**
-     * Set styles as attibute.
+     * Set styles as attribute.
      */
     public function setStyles()
     {


### PR DESCRIPTION
## Summary
- fix 'Set styles as attribute' typo in Box widget

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406536a12883239a16d28d54821968