### PR TITLE
Switch composer test script to pest

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To execute the test suite locally, copy the SQLite environment file:
 cp .env.test.sqlite .env
 ```
 
-Then run `vendor/bin/pest`.
+Then run `composer test` (or `vendor/bin/pest`).
 
 ## Extensions
 <a href="https://super-admin.org/docs/en/extension-development">Extension development</a>

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "scripts": {
         "sass": "sass --watch resources/assets/super-admin/scss/styles.scss:resources/assets/super-admin/css/styles.css resources/assets/super-admin/scss/pages:resources/assets/super-admin/css/pages --style compressed",
-        "test": "./vendor/bin/phpunit"
+        "test": "./vendor/bin/pest"
     },
     "suggest": {
         "intervention/image": "Required to handling and manipulation upload images (~2.3).",


### PR DESCRIPTION
## Summary
- use `vendor/bin/pest` for the composer `test` script
- document using `composer test`

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: deprecated schema)*

------
https://chatgpt.com/codex/tasks/task_e_68418ced4d048323b308826db1240447