### PR TITLE
Improve test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,30 @@ The file `config/admin.php` contains an array of configurations, you can find th
 
 Running Tests
 ------------
-To execute the test suite locally, copy the SQLite environment file:
+Install the project dependencies first:
+
+```bash
+composer install
+```
+
+Copy the SQLite environment file:
 
 ```bash
 cp .env.test.sqlite .env
 ```
 
-Then run `vendor/bin/pest`.
+Then execute the suite with:
+
+```bash
+vendor/bin/pest
+```
+
+If you don't have PHP installed locally, you can run these commands through `docker-compose`:
+
+```bash
+docker-compose run --rm app composer install
+docker-compose run --rm app vendor/bin/pest
+```
 
 ## Extensions
 <a href="https://super-admin.org/docs/en/extension-development">Extension development</a>

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "scripts": {
         "sass": "sass --watch resources/assets/super-admin/scss/styles.scss:resources/assets/super-admin/css/styles.css resources/assets/super-admin/scss/pages:resources/assets/super-admin/css/pages --style compressed",
-        "test": "./vendor/bin/phpunit"
+        "test": "./vendor/bin/pest"
     },
     "suggest": {
         "intervention/image": "Required to handling and manipulation upload images (~2.3).",


### PR DESCRIPTION
## Summary
- align `composer test` script with README
- document how to run tests including composer install and docker-compose usage

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684195ba9d548323af50aecefcc7021a