### PR TITLE
Fix README test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Running Tests
 
 4. Run the tests with Pest:
 
+   ```bash
+   vendor/bin/pest
+   ```
+
 
 ## Extensions
 <a href="https://super-admin.org/docs/en/extension-development">Extension development</a>


### PR DESCRIPTION
## Summary
- add example pest command to run the suite

## Testing
- `vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6844aa5a9ebc8323bcdb22f45e47a79f