### PR TITLE
docs: correct PHP version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@
 
 Requirements
 ------------
- - PHP >= 8.3.0
+ - PHP >= 8.2.0
  - Laravel >= 12.0.0
  - Fileinfo PHP Extension
 
 Installation
 ------------
 
-> This package requires PHP 8.3+ and Laravel 12.0 or up
+> This package requires PHP 8.2+ and Laravel 12.0 or up
 
 First, install laravel (12.0 or up), and make sure that the database connection settings are correct.
 


### PR DESCRIPTION
## Summary
- align README PHP requirement with `composer.json`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844aa6166d48323965fa017a4409358